### PR TITLE
Fix Bug: TitleStyle in yaml not used

### DIFF
--- a/MakePDFCal.py
+++ b/MakePDFCal.py
@@ -152,7 +152,7 @@ def MakePDFMonthCal (year, month, calParams, outputFile):
 
 		pdfFile.set_text_color (calParams['FontColourR'], calParams['FontColourG'], calParams['FontColourB'])
 
-		if (calParams['DayTitleStyle'] == 1):
+		if (calParams['TitleStyle'] == 1):
 
 			pdfFile.set_xy (calParams['PageXOrigin'] + calXOffset, calParams['PageYOrigin'] + calYOffset)
 			pdfFile.set_font (calParams['Font'], style=fontStyle, size=INCH_TO_POINT*calParams['BlockMonthTitleHeight']*calHeight) 
@@ -162,7 +162,7 @@ def MakePDFMonthCal (year, month, calParams, outputFile):
 		        	      border=calParams['Debug'], align='C')
 
 
-		elif (calParams['DayTitleStyle'] == 2):
+		elif (calParams['TitleStyle'] == 2):
 
 			pdfFile.set_font (calParams['Font'], style=fontStyle, size=INCH_TO_POINT*calParams['BlockMonthTitleHeight']*calHeight)
 			monthFontWidth = pdfFile.get_string_width (calendar.month_name[calMonth])


### PR DESCRIPTION
Fix now has the title text generation use calParams['TitleStyle']. It erroneously used the DayTitleStyle parameter before.

Might require regenerating some/all of the pdf files in the SampleOutput folder. I'm not sure; I haven't checked the designs of the generated calendars.

P.S Thanks for making this repo! It helped me make some calendars to print out.